### PR TITLE
changed metatag feed to podcast feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ description: Loosely Coupled aims to expose listeners to professional practices,
 date_format: "ordinal"
 
 # RSS / Email (optional) subscription links (change if using something like Feedburner)
-subscribe_rss: /atom.xml
+subscribe_rss: http://feeds.feedburner.com/looselycoupled-podcast
 subscribe_email:
 # RSS feeds can list your email address if you like
 email:


### PR DESCRIPTION
wanted to subscribe to you podcast but my app only recognized your atom feed which is not a podcast feed
so adding your real podcast feed to the metatag